### PR TITLE
SCR - Remove County Roads from MS,OK,TX

### DIFF
--- a/WME-RSA.user.js
+++ b/WME-RSA.user.js
@@ -216,8 +216,6 @@ const RoadAbbr = {
         "Mississippi": {
             'I-': 5,
             'US-': 6,
-            "CH-": 2002,
-            "CR-": 2002,
             "SH-": 7,
             "SR-": 7,
             "MS-": 7
@@ -320,8 +318,6 @@ const RoadAbbr = {
         "Oklahoma": {
             'I-': 5,
             'US-': 6,
-            "CH-": 2002,
-            "CR-": 2002,
             "SH-": 2097,
             "SR-": 2097
         },
@@ -378,8 +374,6 @@ const RoadAbbr = {
         "Texas": {
             'I-': 5,
             'US-': 6,
-            "CH-": 2002,
-            "CR-": 2002,
             "SH-": 2117,
             "SR-": 2117
         },


### PR DESCRIPTION
Removing County Roads from being highlighted in Mississippi, Texas, and Oklahoma.  These three states do not routinely use shields for county roads, only street blades.
--turnertr